### PR TITLE
[DRAFT] Update endpoint to join newlines and send message to slack once to al…

### DIFF
--- a/newsfragments/1.feature.rst
+++ b/newsfragments/1.feature.rst
@@ -1,0 +1,1 @@
+Instead of splitting lines, enqueue multiline messages, handled nicely by Slack.

--- a/pmxbot/webhooks.py
+++ b/pmxbot/webhooks.py
@@ -9,7 +9,6 @@ import logging
 import codecs
 import textwrap
 import urllib.parse
-from itertools import chain
 from typing import List, Union
 
 from .compat.py311 import resources

--- a/pmxbot/webhooks.py
+++ b/pmxbot/webhooks.py
@@ -280,17 +280,15 @@ class Server:
     @classmethod
     def send_to(cls, channel, *msgs):
         cls.queue.append(pmxbot.core.SwitchChannel(channel))
-        # We must send line-by-line, so split multiline messages
-        lines = chain(*(msg.splitlines() for msg in msgs))
-        cls.queue.extend(lines)
+        cls.queue.extend(msgs)
 
     @cherrypy.expose
     @cherrypy.tools.actually_decode()
     def default(self, channel):
         lines = [line.rstrip() for line in cherrypy.request.body]
-        msg_len = sum(len(line.encode('utf-8')) for line in lines)
-        self.send_to(channel, *lines)
-        return '{msg_len} bytes queued for {channel}'.format(**locals())
+        payload = '\n'.join(lines)
+        self.send_to(channel, payload)
+        return f'{len(lines)} bytes queued for {channel}'
 
     @cherrypy.expose
     def bookmarklet(self):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -21,7 +21,7 @@ class ServerTest(helper.CPWebCase):
 
     def test_send_to_multiline(self):
         Server.send_to('channel', 'msg1\nmsg2', 'msg3')
-        assert Server.queue == ['channel', 'msg1', 'msg2', 'msg3']
+        assert Server.queue == ['channel', 'msg1\nmsg2', 'msg3']
 
     def test_send_to_multiple(self):
         Server.send_to('chan1', 'msg1')
@@ -33,8 +33,7 @@ class ServerTest(helper.CPWebCase):
             'chan2',
             'msg2',
             'chan3',
-            'msg3',
-            'msg4',
+            'msg3\nmsg4',
         ]
 
 


### PR DESCRIPTION
Update endpoint to join newlines and send message to slack once, to allow posting multi-line strings to slack and reduce chances of API throttling (which we're seeing quite a lot these days). The previous code had a comment that said `We must send line-by-line, so split multiline messages` which has been there since the beginning (I checked the git history). However according to the slack docs (https://api.slack.com/reference/surfaces/formatting#line-breaks), newline characters in messages are supported. I'm thinking this was an edge case/limitation of the slack API years ago. If there was specific reasoning why we are splitting lines then please enlighten me :) 

I've tested this and verified it as working...

**Before:**
<img width="626" alt="image" src="https://github.com/chrisBrookes93/pmxbot.webhooks/assets/1598192/c7ab4e21-da22-4dcc-9759-fc46b14f8fb7">

**After:**
<img width="297" alt="image" src="https://github.com/chrisBrookes93/pmxbot.webhooks/assets/1598192/958a1a9c-60a7-4f8b-a7a4-0b25d50fb919">


**Test script used:**
```
import requests
message = "My Shopping List:\n- Cheese\n- Butter\n- Milk"
url = "http://localhost:8080/chris.brookes"
resp = requests.post(url, data=message)
```

Please inform me if there are other edge cases in the API that I haven't considered!
